### PR TITLE
fix: expect empty array is correct

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,11 @@
 {
+  "contributors": [
+    {
+      "name" : "skmdev",
+      "email" : "skmdev29@gmail.com",
+      "url" : "https://github.com/skmdev"
+    }
+  ],
   "dependencies": {
     "jest-get-type": "22.4.3",
     "jest-matcher-utils": "23.6.0",

--- a/src/toBeTypeOf.ts
+++ b/src/toBeTypeOf.ts
@@ -11,19 +11,19 @@ declare global {
   }
 }
 
-export function toBeTypeOf <T>(this: MatcherUtils | void, actual: T, expected: T): JestResult {
-  const pass = getType(actual) === getType(expected)
+export function toBeTypeOf <T>(this: MatcherUtils | void, received: T, expected: T): JestResult {
+  const pass = getType(received) === getType(expected)
 
   return {
     message: () => pass ? '' :
       `${matcherHint('.toBeTypeOf')}\n` +
       `\n` +
       `Received:\n` +
-      `  ${printReceived(getType(actual))}\n` +
+      `  ${printReceived(getType(received))}\n` +
       `Expected:\n` +
       `  ${printExpected(getType(expected))}\n` +
       `For value:\n` +
-      JSON.stringify(actual, null, 2),
+      JSON.stringify(received, null, 2),
     pass,
   }
 }

--- a/src/toMatchOneOf.test.ts
+++ b/src/toMatchOneOf.test.ts
@@ -35,6 +35,18 @@ describe('toMatchOneOf', () => {
     expect(undefined).toMatchOneOf([2, undefined])
   })
 
+  it('passes when optional properties are inferred from array siblings', () => {
+    const received = [
+        { one: 1 },
+        { one: 1, two: 2 },
+      ]
+
+    expect(received).toMatchOneOf([[
+      { one: 5 },
+      { one: 3, two: 4 },
+    ]])
+  })
+
   it('fails when received is undefined and none of the expected values are undefined', () => {
     expect(undefined).not.toMatchOneOf([2, 'b'])
   })
@@ -47,20 +59,41 @@ describe('toMatchOneOf', () => {
     expect(['abc', 'def']).toMatchOneOf(['ghi'])
   })
 
-  it('succeeds when both the expected and actual values are empty arrays', () => {
-    expect([]).toMatchOneOf([])
+  it('passes when both the expected and received values are empty arrays', () => {
+    expect([]).toMatchOneOf([[]])
   })
 
-  it('will accept values when the expected is an empty array', () => {
-    expect({ a: []}).toMatchOneOf([{ a: []}])
+  it('passes when both the expect and received values of a property are an empty array', () => {
+    expect({ a: [] }).toMatchOneOf([{ a: [] }])
   })
 
-  it('fails passes a object when the expected is an empty array', () => {
-    expect({ one: 1, two: 2}).not.toMatchOneOf([])
+  it('fails when the expected values are an empty array', () => {
+    expect({ one: 1, two: 2 }).not.toMatchOneOf([])
   })
 
-  it('will accept values when the expected is an empty array', () => {
-    expect({ a: [1, 2, 3]}).toMatchOneOf([{ a: []}])
+  it('fails when the expected value is an empty array, but the received value is non-empty', () => {
+    expect({ a: [1, 2, 3] }).not.toMatchOneOf([{ a: [] }])
+  })
+
+  it('passes when the expected value is a non-empty array, but the received value is empty', () => {
+    expect({ a: [] }).toMatchOneOf([{ a: [] }, { a: [1, 2, 3] }])
+  })
+
+  it('fails when the expected values dont have all of the keys of non-empty received values', () => {
+    expect([
+      { one: 1 },
+      { one: 1 },
+    ]).not.toMatchOneOf([
+      [],
+      [
+        { one: 3, two: 4 },
+        { one: 5, two: 5 },
+      ],
+      [
+        { one: 4, two: 4 },
+        { one: 6, two: 6 },
+      ],
+    ])
   })
 
   it(`fails an array if an element of the received array doesn't match a type in the expected array`, () => {
@@ -69,15 +102,15 @@ describe('toMatchOneOf', () => {
   })
 
   it('passes when all of the keys on received match types on the expected values', () => {
-    const optionOne = { a: 3, b : 'three' }
-    const optionTwo = { a: 4, b : 'four' }
+    const optionOne = { a: 3, b: 'three' }
+    const optionTwo = { a: 4, b: 'four' }
 
     expect({ a: 2, b: 'two' }).toMatchOneOf([optionOne, optionTwo])
   })
 
   it('passes when the received object provides more keys than the expected values', () => {
-    const optionOne = { a: 3, b : 'three' }
-    const optionTwo = { a: 4, b : 'four' }
+    const optionOne = { a: 3, b: 'three' }
+    const optionTwo = { a: 4, b: 'four' }
 
     expect({ a: 2, b: 'two', c: false }).toMatchOneOf([optionOne, optionTwo])
   })
@@ -90,7 +123,7 @@ describe('toMatchOneOf', () => {
   })
 
   it('fails when the received object is missing keys if they are present on all expected values, even null', () => {
-    expect({ a: 2 }).not.toMatchOneOf([{ a: 3, b : '3' }, { a: 4, b : null }])
+    expect({ a: 2 }).not.toMatchOneOf([{ a: 3, b: '3' }, { a: 4, b: null }])
   })
 
   it('fails when the received has a null key when none of the expected values have the key as null', () => {
@@ -122,50 +155,86 @@ describe('toMatchOneOf', () => {
   })
 
   it('deeply nested objects', () => {
-    const example = { a: { b: { c: {
-      one: 1,
-      two: 2,
-    }}}}
+    const example = {
+      a: {
+        b: {
+          c: {
+            one: 1,
+            two: 2,
+          },
+        },
+      },
+    }
 
-    const exampleA = { a: { b: { c: {
-      two: 2,
-    }}}}
-    const exampleB = { a: { b: { c: {
-      one: 7,
-      two: 2,
-    }}}}
+    const exampleA = {
+      a: {
+        b: {
+          c: {
+            two: 2,
+          },
+        },
+      },
+    }
+    const exampleB = {
+      a: {
+        b: {
+          c: {
+            one: 7,
+            two: 2,
+          },
+        },
+      },
+    }
 
     expect(example).toMatchOneOf([exampleA, exampleB])
   })
 
   it('deeply nested objects - failure case', () => {
-    const example = { a: { b: { c: {
-      one: 1,
-    }}}}
+    const example = {
+      a: {
+        b: {
+          c: {
+            one: 1,
+          },
+        },
+      },
+    }
 
-    const exampleA = { a: { b: { c: {
-      two: 2,
-    }}}}
-    const exampleB = { a: { b: { c: {
-      one: 7,
-      two: 2,
-    }}}}
+    const exampleA = {
+      a: {
+        b: {
+          c: {
+            two: 2,
+          },
+        },
+      },
+    }
+    const exampleB = {
+      a: {
+        b: {
+          c: {
+            one: 7,
+            two: 2,
+          },
+        },
+      },
+    }
 
     expect(example).not.toMatchOneOf([exampleA, exampleB])
   })
 
   it('deeply nested objects with null subtrees', () => {
-    const example = { a: { b: null }}
-    const exampleA = { a: { b: null }}
-    const exampleB = { a: { b: { c: true }}}
+    const example = { a: { b: null } }
+    const exampleA = { a: { b: null } }
+    const exampleB = { a: { b: { c: true } } }
 
     expect(example).toMatchOneOf([exampleA, exampleB])
   })
 
   it('deeply nested objects with null subtrees - failure case', () => {
-    const example =  { a: { b: null }}
-    const exampleA = { a: { b: { c: true }}}
-    const exampleB = { a: { b: { c: true }}}
+    const example = { a: { b: null } }
+    const exampleA = { a: { b: { c: true } } }
+    const exampleB = { a: { b: { c: true } } }
 
     expect(example).not.toMatchOneOf([exampleA, exampleB])
   })
@@ -205,10 +274,10 @@ describe('toMatchOneOf', () => {
 
   it('deeply nested objects with missing subtrees - failure case', () => {
     const exampleA = {}
-    const exampleB = { b: { one: 7, two: 2 }}
-    const exampleC = { b: { one: 8, two: 3 }}
+    const exampleB = { b: { one: 7, two: 2 } }
+    const exampleC = { b: { one: 8, two: 3 } }
 
-    expect({ b: { two: 2 }}).not.toMatchOneOf([exampleA, exampleB, exampleC])
+    expect({ b: { two: 2 } }).not.toMatchOneOf([exampleA, exampleB, exampleC])
   })
 
   it('deeply nested objects with missing subtrees - failure case', () => {
@@ -217,40 +286,5 @@ describe('toMatchOneOf', () => {
     const exampleC = { one: 8, two: 3 }
 
     expect({ two: 2 }).not.toMatchOneOf([exampleA, exampleB, exampleC])
-  })
-
-  it('deeply nested arrays - success case', () => {
-    const example = { a: { b: [
-      { one: 1, two: 2 },
-      { one: 1 },
-    ]}}
-
-    const exampleA = { a: {} }
-    const exampleB = { a: { b: []}}
-    const exampleC = { a: { b: [
-      { one: 3, two: 4 },
-      { one: 5 },
-    ]}}
-
-    expect(example).toMatchOneOf([exampleA, exampleB, exampleC])
-  })
-
-  it('deeply nested arrays - failure case', () => {
-    const example = { a: { b: [
-      { one: 1 },
-      { one: 1 },
-    ]}}
-
-    const exampleA = { a: { b: []}}
-    const exampleB = { a: { b: [
-      { one: 3, two: 4 },
-      { one: 5, two: 5 },
-    ]}}
-    const exampleC = { a: { b: [
-      { one: 4, two: 4 },
-      { one: 6, two: 6 },
-    ]}}
-
-    expect(example).not.toMatchOneOf([exampleA, exampleB, exampleC])
   })
 })

--- a/src/toMatchOneOf.test.ts
+++ b/src/toMatchOneOf.test.ts
@@ -47,7 +47,7 @@ describe('toMatchOneOf', () => {
     expect(['abc', 'def']).toMatchOneOf(['ghi'])
   })
 
-  it('expect empty array is correct', () => {
+  it('succeeds when both the expected and actual values are empty arrays', () => {
     expect([]).toMatchOneOf([])
   })
 

--- a/src/toMatchOneOf.test.ts
+++ b/src/toMatchOneOf.test.ts
@@ -51,8 +51,16 @@ describe('toMatchOneOf', () => {
     expect([]).toMatchOneOf([])
   })
 
-  it('will not accept values when the expected is an empty array', () => {
-    expect({ a: [1, 2, 3]}).not.toMatchOneOf([{ a: []}])
+  it('will accept values when the expected is an empty array', () => {
+    expect({ a: []}).toMatchOneOf([{ a: []}])
+  })
+
+  it('fails passes a object when the expected is an empty array', () => {
+    expect({ one: 1, two: 2}).not.toMatchOneOf([])
+  })
+
+  it('will accept values when the expected is an empty array', () => {
+    expect({ a: [1, 2, 3]}).toMatchOneOf([{ a: []}])
   })
 
   it(`fails an array if an element of the received array doesn't match a type in the expected array`, () => {

--- a/src/toMatchOneOf.test.ts
+++ b/src/toMatchOneOf.test.ts
@@ -47,6 +47,10 @@ describe('toMatchOneOf', () => {
     expect(['abc', 'def']).toMatchOneOf(['ghi'])
   })
 
+  it('expect empty array is correct', () => {
+    expect([]).toMatchOneOf([])
+  })
+
   it('will not accept values when the expected is an empty array', () => {
     expect({ a: [1, 2, 3]}).not.toMatchOneOf([{ a: []}])
   })

--- a/src/toMatchOneOf.ts
+++ b/src/toMatchOneOf.ts
@@ -52,7 +52,7 @@ export function toMatchOneOf<T extends {}>(
 ): JestResult {
   if (isArray(received)) {
     if (received.length === 0) {
-      if (some(expectedValues, isArray)) {
+      if (some(expectedValues, isArray) || expectedValues.length === 0) {
         return successResult
       } else {
         return {

--- a/src/toMatchOneOf.ts
+++ b/src/toMatchOneOf.ts
@@ -1,4 +1,7 @@
-import { every, find, flatMap, flatten, head, isArray, isUndefined, keys as keysOf, map, some, uniq } from 'lodash'
+import {
+  every, find, flatMap, flatten, head, isArray, isUndefined, keys as keysOf, map, partition
+  , some, uniq,
+} from 'lodash'
 import * as getType from 'jest-get-type'
 import * as util from 'jest-matcher-utils'
 import { JestResult } from './common-types'
@@ -63,11 +66,24 @@ export function toMatchOneOf<T extends {}>(
     }
 
     if (expectedValues.length === 0) {
-      return successResult
+      return {
+        message: () =>
+          `${util.matcherHint('.toMatchShapeOf')}\n` +
+          `\n` +
+          `For${(keys.length === 0) ? '' : ' received' + keys.join('')}:\n` +
+          `  type: ${util.RECEIVED_COLOR(getType(received))}\n` +
+          `  value: ${util.printReceived(received)}\n` +
+          `'Expected' is an empty array.` +
+          //  tslint:disable-next-line:max-line-length
+          ((keys.length === 0) ? '' : `\nIf you don't want to check the values in this array, you can omit expected${keys.join('')} entirely`),
+        pass: false,
+      }
     }
 
-    const results = received.map((cActual, index) =>
-      toMatchOneOf.bind(this)(cActual, expectedValues, [...keys, `[${index}]`]),
+    const [expectedArrayValues, expectedNonArrayValues] = partition(expectedValues, isArray)
+    const combinedExpectedValues = expectedNonArrayValues.concat(flatten(expectedArrayValues))
+    const results = map(received, (cActual, index) =>
+      toMatchOneOf.bind(this)(cActual, combinedExpectedValues, [...keys, `[${index}]`]),
     )
     if (every(results, ({ pass }) => pass)) {
       return successResult
@@ -85,23 +101,24 @@ export function toMatchOneOf<T extends {}>(
     some(expectedValues, (expectedValue) => expectedValue != null && typeof expectedValue === 'object')
   ) {
     const validKeys: Array<keyof T> = uniq(flatMap(expectedValues, keysOf as (val: T) => Array<keyof T>))
-    const possibleValuesForKey = validKeys.reduce(
+    const possibleValuesForKey: { [Key in keyof T]: Array<T[Key]> } = validKeys.reduce(
       (acc: { [Key in keyof T]: Array<T[Key]> }, key: keyof T) => {
-        acc[key] = flatten(
+        acc[key] = (
           expectedValues
             .filter(expected => !isUndefined(expected))
-            .map(e => e && e[key]),
+            .map(e => e && e[key])
         )
         return acc
       },
       {} as { [Key in keyof T]: Array<T[Key]> },
     )
 
-    const results: Array<JestResult> = map(
+    const results: Array<JestResult> = map<{ [Key in keyof T]: Array<T[Key]> }, JestResult>(
       possibleValuesForKey,
-      (values: Array<T[keyof T]>, key: keyof T): JestResult =>
-        (toMatchOneOf.bind(this)(received[key], values, [...keys, `.${key}`])),
-    ) as any // tslint:disable-line:no-any TODO ts thinks that results is a boolean array?
+      // `key` should be `key: keyof T` but the lodash typings insist
+      (values: Array<T[keyof T]>, key: string): JestResult =>
+        (toMatchOneOf.bind(this)(received[key as keyof T], values, [...keys, `.${key}`])),
+    )
 
     const failedResult = find(results, result => !result.pass)
 

--- a/src/toMatchOneOf.ts
+++ b/src/toMatchOneOf.ts
@@ -63,10 +63,7 @@ export function toMatchOneOf<T extends {}>(
     }
 
     if (expectedValues.length === 0) {
-      return {
-        message: () => formatError(received, ['[]'], keys),
-        pass: false,
-      }
+      return successResult
     }
 
     const results = received.map((cActual, index) =>

--- a/src/toMatchShapeOf.test.ts
+++ b/src/toMatchShapeOf.test.ts
@@ -16,23 +16,23 @@ describe('toMatchShapeOf', () => {
   })
 
   it('checks that expected has the same shape, with the same keys and types', () => {
-    const actual = { a: 4, b: 17, c: 'cat', d: []  }
+    const received = { a: 4, b: 17, c: 'cat', d: []  }
     const expected = { a: '', b: false, c: null, d: true, e: [] }
 
-    const { message, pass } = toMatchShapeOf(actual as any, expected)
+    const { message, pass } = toMatchShapeOf(received as any, expected)
     expect(pass).toBe(false)
     expect(message()).not.toBe('')
   })
 
   it('checks that expected has the same shape, with the same keys and types', () => {
-    const actual = {
+    const received = {
       a: 1, b: null, c: 3, d: { one: 'a', two: 'b', three: 'c' }, e: null, f: undefined,
     }
     const expected = {
       a: false, b: { alpha: 7, beta: 8 }, c: false, d: { one: 1, two: 2, three: 3 }, e: false, g: true,
     }
 
-    const { message, pass } = toMatchShapeOf(actual as any, expected)
+    const { message, pass } = toMatchShapeOf(received as any, expected)
     expect(pass).toBe(false)
     expect(message()).not.toBe('')
   })
@@ -51,7 +51,7 @@ describe('toMatchShapeOf', () => {
     expect(failResult.pass).toBe(false)
   })
 
-  it('passes when actual has keys which are not on expected', () => {
+  it('passes when received has keys which are not on expected', () => {
     const extraKeysResult = toMatchShapeOf({ a: 1, b: 3, c: [] } as any, { a: 1, b: 2 })
     expect(extraKeysResult.pass).toBe(true)
   })
@@ -59,21 +59,5 @@ describe('toMatchShapeOf', () => {
   it('fails when expected is missing a key in test', () => {
     const missingKeyResult = toMatchShapeOf({ a: 1 } as any, { a: 1, b: 2 })
     expect(missingKeyResult.pass).toBe(false)
-  })
-
-  it('passes when expect Array<any> in test', () => {
-    interface Test {
-      test: Array<any>
-    }
-
-    const checkValue: Test = {
-      test: [2, 3, 4]
-    }
-
-    const expectedValue: Test = {
-      test: []
-    }
-
-    expect(checkValue).toMatchShapeOf(expectedValue)
   })
 })

--- a/src/toMatchShapeOf.test.ts
+++ b/src/toMatchShapeOf.test.ts
@@ -60,4 +60,20 @@ describe('toMatchShapeOf', () => {
     const missingKeyResult = toMatchShapeOf({ a: 1 } as any, { a: 1, b: 2 })
     expect(missingKeyResult.pass).toBe(false)
   })
+
+  it('passes when expect Array<any> in test', () => {
+    interface Test {
+      test: Array<any>
+    }
+
+    const checkValue: Test = {
+      test: [2, 3, 4]
+    }
+
+    const expectedValue: Test = {
+      test: []
+    }
+
+    expect(checkValue).toMatchShapeOf(expectedValue)
+  })
 })


### PR DESCRIPTION
When using `toMatchShapeOf` to check the shape of empty array will occurs error.

Therefore this PR is try to fix this error.

```
const foo = {
   test: []
}
const bar = {
   test: []
}
 expect(foo).toMatchShapeOf(bar);
```

```
    expect(received).toMatchShapeOf(expected)

    For received.test:
      type: array
      value: []
    Expected type to be one of

      68 |       test: [],
      69 |     };
    > 70 |     expect(foo).toMatchShapeOf(bar);
         |                 ^
      71 |   });
      72 | 
```