### PR TITLE
Aligned with jest Matchers interface type

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
       "name" : "skmdev",
       "email" : "skmdev29@gmail.com",
       "url" : "https://github.com/skmdev"
+    },
+    {
+      "name" : "Nidin Vinayakan",
+      "email" : "01@01alchemist.com",
+      "url" : "https://github.com/nidin"
     }
   ],
   "dependencies": {

--- a/src/toBeTypeOf.ts
+++ b/src/toBeTypeOf.ts
@@ -5,7 +5,7 @@ import MatcherUtils = jest.MatcherUtils
 
 declare global {
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toBeTypeOf(expected: any): R, // tslint:disable-line:no-any
     }
   }

--- a/src/toMatchOneOf.ts
+++ b/src/toMatchOneOf.ts
@@ -10,7 +10,7 @@ import MatcherUtils = jest.MatcherUtils
 
 declare global {
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toMatchOneOf(expected: Array<any>): R, // tslint:disable-line:no-any
     }
   }

--- a/src/toMatchShapeOf.ts
+++ b/src/toMatchShapeOf.ts
@@ -4,7 +4,7 @@ import MatcherUtils = jest.MatcherUtils
 
 declare global {
   namespace jest {
-    interface Matchers<R> {
+    interface Matchers<R, T> {
       toMatchShapeOf(expected: any): R, // tslint:disable-line:no-any
     }
   }


### PR DESCRIPTION
### Changes
* Original jest interface of `Matchers` has an extra type parameter T
* Added this missing type parameter T to `toBeTypeOf `, `toMatchOneOf `, `toMatchShapeOf ` declerations

### TypeError Screenshot
![image](https://user-images.githubusercontent.com/198246/73052968-ca5f3b80-3e86-11ea-9316-bcc011d17b0d.png)
