### PR TITLE
Update jest peerDependency version to "25.x || 26.x"

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "types": "dist/index.d.ts",
   "name": "jest-to-match-shape-of",
   "peerDependencies": {
-    "jest": "25.x"
+    "jest": "25.x || 26.x"
   },
   "repository": "git@github.com:Dean177/jest-to-match-shape-of.git",
   "scripts": {


### PR DESCRIPTION
Resolves #80 

Changes:
- updated jest peerDependency version to "25.x || 26.x"

Notes:
- all the tests are passing
- I've done a dummy test importing jest@26.6 alongside the updated package locally and the unmet peer dependency warning is gone

Let me know if I've missed something or if there is anything else I should change.

P.s.:
- this is my first contribution to open-source 😁 