### PR TITLE
Fix peerDependencies.jest for newer Jest ver. Fixes #87

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "types": "dist/index.d.ts",
   "name": "jest-to-match-shape-of",
   "peerDependencies": {
-    "jest": ">=25x"
+    "jest": ">=25"
   },
   "repository": "git@github.com:Dean177/jest-to-match-shape-of.git",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "types": "dist/index.d.ts",
   "name": "jest-to-match-shape-of",
   "peerDependencies": {
-    "jest": "25.x || 26.x"
+    "jest": ">=25x"
   },
   "repository": "git@github.com:Dean177/jest-to-match-shape-of.git",
   "scripts": {


### PR DESCRIPTION
Should fix package with `Jest 27`