### PR TITLE
[DOCS]: Improve installation and setup guide

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,67 +4,87 @@
 [![codecov](https://codecov.io/gh/Dean177/jest-to-match-shape-of/branch/master/graph/badge.svg)](https://codecov.io/gh/Dean177/jest-to-match-shape-of)
 [![Npm](https://badge.fury.io/js/jest-to-match-shape-of.svg)](https://www.npmjs.com/package/jest-to-match-shape-of)
 
-
-A [Jest matcher](https://facebook.github.io/jest/docs/en/using-matchers.html) to verify the structure of an object, particularly useful for api integration tests
+A [Jest matcher](https://facebook.github.io/jest/docs/en/using-matchers.html) to verify the structure of an object, particularly useful for API integration tests.
 
 ![example-gif](./example/huge-demo-gif.gif)
 
 ## Installation
 
+First install the package via `npm`, `pnpm` or `yarn`:
+
 ```bash
-yarn add jest-to-match-shape-of
+npm install --save-dev jest-to-match-shape-of
 ```
 
 ```bash
-npm install jest-to-match-shape-of --save
+pnpm add --dev jest-to-match-shape-of
 ```
 
-In your setupTests.js
+```bash
+yarn add --dev jest-to-match-shape-of
+```
+
+Then create a file to setup your tests. This guide uses `test/setup.js` (for Javascript projects) or `test/setup.ts` (for Typescript projects), but it should still work if you can place it somewhere else.
+
+Add the following to `test/setup.js` file (if you are using CommonJS):
+
 ```javascript
-// src/setupTests.js
+// /test/setup.js
+// Setup your test environment
+
 const { toMatchOneOf, toMatchShapeOf } = require('jest-to-match-shape-of')
 
 expect.extend({
-  toMatchOneOf,
-  toMatchShapeOf,
+	toMatchOneOf,
+	toMatchShapeOf,
 })
 ```
-or if you are using Typescript
+
+If you are using ESM or Typescript, use the following instead:
 
 ```typescript
-// src/setupTests.ts
+// /test/setup.ts
+// Setup your test environment
+
 import { toMatchOneOf, toMatchShapeOf } from 'jest-to-match-shape-of'
 
 expect.extend({
-  toMatchOneOf,
-  toMatchShapeOf,
+	toMatchOneOf,
+	toMatchShapeOf,
 })
 ```
 
-Then in the "jest" section of your package.json add the following:
-`"setupTestFrameworkScriptFile": "<rootDir>/src/setupTests.js"`
+Then add the following to your [Jest configuration](https://jestjs.io/docs/configuration):
 
-or for typescript:
-`"setupTestFrameworkScriptFile": "<rootDir>/src/setupTests.ts"`
+```jsonc
+// CommonJS/ESM
+"setupFilesAfterEnv": ["./test/setup.js"]
 
-### Installation with create-react-app
-For project created using CRA (create-react-app) you need to add setup code to the `setupTests.js` file, there is no need to modify `package.json`.
-
+// Typescript
+"setupFilesAfterEnv": ["./test/setup.ts"]
 ```
-// src/setupTests.js
-const { toMatchOneOf, toMatchShapeOf } = require('jest-to-match-shape-of')
-// or with ES6 module import { toMatchOneOf, toMatchShapeOf } from 'jest-to-match-shape-of';
+
+For usage in a project created using CRA ([`create-react-app`](https://create-react-app.dev/)) you simply need to add the above setup code to the test setup file (usually `src/setupTests.js` or `src/setupTests.ts`), there is no need to modify your Jest configuration.
+
+```javascript
+import '@testing-library/jest-dom'
+
+import { toMatchOneOf, toMatchShapeOf } from 'jest-to-match-shape-of'
 
 expect.extend({
-  toMatchOneOf,
-  toMatchShapeOf,
+	toMatchOneOf,
+	toMatchShapeOf,
 })
 ```
 
 ## Usage
 
-```javascript
-expect(someThing).toMatchOneOf([someOtherThingA, someOtherThingB, someOtherThingC])
+```typescript
+expect(someThing).toMatchOneOf([
+	someOtherThingA,
+	someOtherThingB,
+	someOtherThingC,
+])
 expect(someThing).toMatchShapeOf(someOtherThing)
 ```
 
@@ -72,64 +92,68 @@ Works particularly well when being used with [Typescript](https://www.typescript
 
 ```typescript
 type Resource = {
-  maybeNumber: number | null, 
-  someString: string,
+	maybeNumber: number | null
+	someString: string
 }
 
 const testResource: Resource = {
-  maybeNumber: 6,
-  someString: 'some real looking data',
+	maybeNumber: 6,
+	someString: 'some real looking data',
 }
 
 const testResourceAlt: Resource = {
-  maybeNumber: null,
-  someString: 'some real looking data',
+	maybeNumber: null,
+	someString: 'some real looking data',
 }
 
 describe('an api', () => {
-  it('returns what I was expecting', () => {
-    return fetch('/resources/1').then(response => response.json()).then((data) => {
-      expect(data).toMatchShapeOf(testResource)  
-    })            
-  })
-  
-  it('could return a couple of different things', () => {
-    return fetch('/resources/1').then(response => response.json()).then((data) => {
-      expect(data).toMatchOneOf([testResource, testResourceAlt])  
-    })    
-  })
-})
+	it('returns what I was expecting', () => {
+		return fetch('/resources/1')
+			.then((response) => response.json())
+			.then((data) => {
+				expect(data).toMatchShapeOf(testResource)
+			})
+	})
 
+	it('could return a couple of different things', () => {
+		return fetch('/resources/1')
+			.then((response) => response.json())
+			.then((data) => {
+				expect(data).toMatchOneOf([testResource, testResourceAlt])
+			})
+	})
+})
 ```
 
-### How to match a shape with optional fields?
+### Matching Optional Fields
 
-Sometimes, the expected shape may vary during integration tests. (e.g: A field may be missing)
+Sometimes, the expected shape may vary during integration tests (for example, a field may be missing).
 
 If you want to make a shape allow optional fields, the simplest way is to remove those fields from the expected shape, as follow:
 
-```ts
-toMatchOneOf([{ ant: 17 }]) // bat is optional here
+```typescript
+toMatchShapeOf({ ant: 17 }) // `bat` is optional here
 ```
 
-A more robust alternative is to define all possible shapes, this way you still test the types of the properties: 
+A more robust alternative is to define all possible shapes, this way you still test the types of the properties:
 
-```ts
-toMatchOneOf([{ ant: 17, bat: 176 }, { ant: 17 }]) // bat is still optional, but must be numeric
+```typescript
+toMatchOneOf([{ ant: 17, bat: 176 }, { ant: 17 }]) // `bat` is still optional, but must be numeric
 ```
 
 ## Motivation
 
-I wanted to write integration test for my frontend code but found it was tedious, brittle and 
-hard to debug when I encountered a legitimate failure. 
+I wanted to write integration test for my frontend code but found it was tedious, brittle and
+hard to debug when I encountered a legitimate failure.
 
 I realised that
+
 - Almost all of the errors were due to bad data from the API, most often missing data
-- I did not care about *exactly* what data came back, but more about the *shape* of the data.
+- I did not care about _exactly_ what data came back, but more about the _shape_ of the data.
 - Since I was using React and Typescript I could be confident my app would work as intended if the types were correct
-- Thanks to [Enzyme](https://github.com/airbnb/enzyme) I already had a great way to test my component interactions
- 
- `toMatchShapeOf` hopefully achieves a lot of the value of full blown integration test written with something like 
+- Thanks to [Enzyme](https://github.com/airbnb/enzyme), I already had a great way to test my component interactions
+
+`toMatchShapeOf` hopefully achieves a lot of the value of full blown integration test written with something like
 [Nightwatch](http://nightwatchjs.org/) whilst being simpler to write, understand and debug.
 
-Additionally I found that the test data I created for use with this matcher were useful for other unit tests in my application.
+I also found out that the test data I created for use with this matcher was useful for other unit tests in my application.

--- a/Readme.md
+++ b/Readme.md
@@ -24,7 +24,7 @@ pnpm add --dev jest-to-match-shape-of
 yarn add --dev jest-to-match-shape-of
 ```
 
-Then create a file to setup your tests. This guide uses `test/setup.js` (for Javascript projects) or `test/setup.ts` (for Typescript projects), but it should still work if you can place it somewhere else.
+Then create a file to setup your tests. This guide uses `test/setup.js` (for Javascript projects) or `test/setup.ts` (for Typescript projects), but it should still work if you place it somewhere else.
 
 Add the following to `test/setup.js` file (if you are using CommonJS):
 
@@ -35,8 +35,8 @@ Add the following to `test/setup.js` file (if you are using CommonJS):
 const { toMatchOneOf, toMatchShapeOf } = require('jest-to-match-shape-of')
 
 expect.extend({
-	toMatchOneOf,
-	toMatchShapeOf,
+  toMatchOneOf,
+  toMatchShapeOf,
 })
 ```
 
@@ -49,8 +49,8 @@ If you are using ESM or Typescript, use the following instead:
 import { toMatchOneOf, toMatchShapeOf } from 'jest-to-match-shape-of'
 
 expect.extend({
-	toMatchOneOf,
-	toMatchShapeOf,
+  toMatchOneOf,
+  toMatchShapeOf,
 })
 ```
 
@@ -72,8 +72,8 @@ import '@testing-library/jest-dom'
 import { toMatchOneOf, toMatchShapeOf } from 'jest-to-match-shape-of'
 
 expect.extend({
-	toMatchOneOf,
-	toMatchShapeOf,
+  toMatchOneOf,
+  toMatchShapeOf,
 })
 ```
 
@@ -81,9 +81,9 @@ expect.extend({
 
 ```typescript
 expect(someThing).toMatchOneOf([
-	someOtherThingA,
-	someOtherThingB,
-	someOtherThingC,
+  someOtherThingA,
+  someOtherThingB,
+  someOtherThingC,
 ])
 expect(someThing).toMatchShapeOf(someOtherThing)
 ```
@@ -92,36 +92,36 @@ Works particularly well when being used with [Typescript](https://www.typescript
 
 ```typescript
 type Resource = {
-	maybeNumber: number | null
-	someString: string
+  maybeNumber: number | null
+  someString: string
 }
 
 const testResource: Resource = {
-	maybeNumber: 6,
-	someString: 'some real looking data',
+  maybeNumber: 6,
+  someString: 'some real looking data',
 }
 
 const testResourceAlt: Resource = {
-	maybeNumber: null,
-	someString: 'some real looking data',
+  maybeNumber: null,
+  someString: 'some real looking data',
 }
 
 describe('an api', () => {
-	it('returns what I was expecting', () => {
-		return fetch('/resources/1')
-			.then((response) => response.json())
-			.then((data) => {
-				expect(data).toMatchShapeOf(testResource)
-			})
-	})
+  it('returns what I was expecting', () => {
+    return fetch('/resources/1')
+      .then((response) => response.json())
+      .then((data) => {
+        expect(data).toMatchShapeOf(testResource)
+      })
+  })
 
-	it('could return a couple of different things', () => {
-		return fetch('/resources/1')
-			.then((response) => response.json())
-			.then((data) => {
-				expect(data).toMatchOneOf([testResource, testResourceAlt])
-			})
-	})
+  it('could return a couple of different things', () => {
+    return fetch('/resources/1')
+      .then((response) => response.json())
+      .then((data) => {
+        expect(data).toMatchOneOf([testResource, testResourceAlt])
+      })
+  })
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
       "name": "Christian Cuna",
       "email": "christian.cuna89@gmail.com",
       "url": "https://github.com/christian-cuna"
+    },
+    {
+      "name": "Vedant K",
+      "email": "gamemaker0042@gmail.com",
+      "url": "https://github.com/gamemaker1"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
Hi there! Thanks for creating and maintaining this awesome package!

While installing the package following the instructions in `readme.md`, I noticed a couple of things: 

1. The config option `setupFilesAfterEnv` mentioned in `readme.md` was [deprecated in Jest v24.0.0](https://github.com/facebook/jest/blob/main/CHANGELOG.md#2400) and replaced with `setupTestFrameworkScriptFile`.
2. The command to install the package through `npm`/`yarn` installed it as a regular dependency. Most users would want to install it as a development dependency and use it only for testing.

This PR fixes the above to issues.

---

> The above in [`keepachangelog.com`](https://keepachangelog.com) format:

### Added

- command to install via [`pnpm`](https://pnpm.io/) in `readme.md`.

### Changed

- use `setupFilesAfterEnv` instead of `setupTestFrameworkScriptFile`, which was [deprecated in Jest v24.0.0](https://github.com/facebook/jest/blob/main/CHANGELOG.md#2400).
- change commands to install package in `readme.md` to install it as a dev dependency.